### PR TITLE
Version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ## Features
 * Supports buying and selling for items and commands.
 ## Required Dependencies
-* PlaceholderAPI
 * Vault
 ## Commands
 - /skymarket - Command to open the shop.
@@ -12,12 +11,16 @@
     - /market
     - /bm
     - /blackmarket
-- /skymarket reload - Reloads the plugin and shop inventory.
+- /skymarket reload - Reloads the plugin.
+- /skymarket refresh - Refreshes the market's inventory.
+- /skymarket time - View when the shop will refresh next.
 ## Permisisons
 - `skymarket.commands.skymarket` - The permission to access the shop.
 - `skymarket.commands.skymarket.reload` - The permission to reload the plugin.
+- `skymarket.commands.skymarket.refresh` - The permission to refresh the shop.
+- `skymarket.commands.skymarket.time` - The permission to view when the shop will refresh next.
 ## Issues, Bugs, or Suggestions
-* Please create a new [Github Issue](https://github.com/lukesky19/SkyShop/issues) with your issue, bug, or suggestion.
+* Please create a new [Github Issue](https://github.com/lukesky19/SkyMarket/issues) with your issue, bug, or suggestion.
 * If an issue or bug, please post any relevant logs containing errors related to SkyShop and your configuration files.
 * I will attempt to solve any issues or implement features to the best of my ability.
 ## FAQ

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,6 @@ repositories {
         name = "Vault Repo"
     }
 
-    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/") {
-        name = "PlaceholderAPI Repo"
-    }
-
     mavenLocal()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.github.lukesky19"
-version = "1.1.1"
+version = "1.2.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,11 +24,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("net.kyori:adventure-api:4.17.0")
     compileOnly("net.kyori:adventure-text-minimessage:4.17.0")
     compileOnly("com.github.lukesky19:SkyLib:1.1.0")
-    compileOnly("com.github.MilkBowl:VaultAPI:1.7")
+    compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.github.lukesky19"
-version = "1.1.0"
+version = "1.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/lukesky19/skymarket/SkyMarket.java
+++ b/src/main/java/com/github/lukesky19/skymarket/SkyMarket.java
@@ -25,6 +25,7 @@ import com.github.lukesky19.skymarket.configuration.manager.SettingsLoader;
 import com.github.lukesky19.skymarket.configuration.manager.MarketLoader;
 import com.github.lukesky19.skymarket.listener.InventoryListener;
 import com.github.lukesky19.skymarket.manager.MarketManager;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
@@ -33,14 +34,13 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.Objects;
+import java.util.List;
 
 public final class SkyMarket extends JavaPlugin {
     private SettingsLoader settingsLoader;
     private LocaleLoader localeLoader;
     private MarketLoader marketLoader;
     private ItemsLoader itemsLoader;
-    private MarketManager marketManager;
     private Economy economy;
 
     public Economy getEconomy() {
@@ -58,11 +58,12 @@ public final class SkyMarket extends JavaPlugin {
         localeLoader = new LocaleLoader(this, this.settingsLoader);
         itemsLoader = new ItemsLoader(this);
         marketLoader = new MarketLoader(this);
-        marketManager = new MarketManager(this, settingsLoader, localeLoader, itemsLoader, marketLoader);
+        MarketManager marketManager = new MarketManager(this, settingsLoader, localeLoader, itemsLoader, marketLoader);
 
         SkyMarketCommand skyMarketCommand = new SkyMarketCommand(this, localeLoader, marketManager);
-        Objects.requireNonNull(Bukkit.getPluginCommand("skymarket")).setExecutor(skyMarketCommand);
-        Objects.requireNonNull(Bukkit.getPluginCommand("skymarket")).setTabCompleter(skyMarketCommand);
+        this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, commands ->
+                commands.registrar().register(skyMarketCommand.createCommand(),
+                        "Command to manage and use the SkyMarket plugin.", List.of("market", "skm", "sm", "blackmarket", "bm")));
 
         Bukkit.getPluginManager().registerEvents(inventoryListener, this);
 
@@ -74,7 +75,6 @@ public final class SkyMarket extends JavaPlugin {
         this.localeLoader.reload();
         this.itemsLoader.reload();
         this.marketLoader.reload();
-        this.marketManager.refreshMarket();
     }
 
     private void setupEconomy() {

--- a/src/main/java/com/github/lukesky19/skymarket/commands/SkyMarketCommand.java
+++ b/src/main/java/com/github/lukesky19/skymarket/commands/SkyMarketCommand.java
@@ -117,6 +117,9 @@ public class SkyMarketCommand implements CommandExecutor, TabCompleter {
                                 player.sendMessage(FormatUtil.format(locale.prefix() + locale.marketRefreshTime(), placeholders));
 
                                 return true;
+                            } else {
+                                sender.sendMessage(FormatUtil.format(player, locale.prefix() + locale.noPermission()));
+                                return false;
                             }
                         }
                     }

--- a/src/main/java/com/github/lukesky19/skymarket/commands/SkyMarketCommand.java
+++ b/src/main/java/com/github/lukesky19/skymarket/commands/SkyMarketCommand.java
@@ -154,10 +154,13 @@ public class SkyMarketCommand implements CommandExecutor, TabCompleter {
         if(args.length == 1) {
             ArrayList<String> subCmds = new ArrayList<>();
             if(sender instanceof Player) {
-                if(sender.hasPermission("skyshop.commands.reload")) subCmds.add("reload");
+                if(sender.hasPermission("skymarket.commands.skymarket.reload")) subCmds.add("reload");
+                if(sender.hasPermission("skymarket.commands.skymarket.time")) subCmds.add("time");
             } else {
                 subCmds.add("reload");
+                subCmds.add("time");
             }
+
             return subCmds;
         }
 

--- a/src/main/java/com/github/lukesky19/skymarket/commands/SkyMarketCommand.java
+++ b/src/main/java/com/github/lukesky19/skymarket/commands/SkyMarketCommand.java
@@ -18,24 +18,22 @@
 package com.github.lukesky19.skymarket.commands;
 
 import com.github.lukesky19.skylib.format.FormatUtil;
+import com.github.lukesky19.skylib.record.Time;
 import com.github.lukesky19.skymarket.SkyMarket;
 import com.github.lukesky19.skymarket.configuration.manager.LocaleLoader;
 import com.github.lukesky19.skymarket.configuration.record.Locale;
 import com.github.lukesky19.skymarket.manager.MarketManager;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.text.SimpleDateFormat;
 import java.util.*;
 
-public class SkyMarketCommand implements CommandExecutor, TabCompleter {
+public class SkyMarketCommand {
     private final SkyMarket skyMarket;
     private final LocaleLoader localeLoader;
     private final MarketManager marketManager;
@@ -49,121 +47,133 @@ public class SkyMarketCommand implements CommandExecutor, TabCompleter {
         this.marketManager = marketManager;
     }
 
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        Locale locale = localeLoader.getLocale();
+    public LiteralCommandNode<CommandSourceStack> createCommand() {
+        LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal("skymarket")
+            .requires(ctx -> ctx.getSender().hasPermission("skymarket.commands.skymarket"))
+                .executes(ctx -> {
+                    Locale locale = localeLoader.getLocale();
 
-        switch(args.length) {
-            case 0 -> {
-                if(sender instanceof Player player) {
-                    if(sender.hasPermission("skymarket.commands.skymarket")) {
-                        if(marketManager.getMarketGUI() != null) {
+                    if(ctx.getSource().getSender() instanceof Player player) {
+                        if (marketManager.getMarketGUI() != null) {
                             marketManager.getMarketGUI().openInventory(skyMarket, player);
-                            return true;
+
+                            return 1;
                         } else {
                             player.sendMessage(FormatUtil.format(locale.prefix() + locale.marketOpenError()));
-                            return false;
+
+                            return 0;
                         }
                     } else {
-                        sender.sendMessage(FormatUtil.format(player, locale.prefix() + locale.noPermission()));
-                        return false;
+                        skyMarket.getComponentLogger().info(FormatUtil.format(locale.inGameOnly()));
+
+                        return 0;
                     }
-                } else {
-                    skyMarket.getComponentLogger().info(locale.inGameOnly());
-                    return false;
-                }
-            }
+                });
 
-            case 1 -> {
-                switch(args[0].toLowerCase()) {
-                    case "reload" -> {
-                        if (sender instanceof Player player) {
-                            if (player.hasPermission("skymarket.commands.skymarket.reload")) {
-                                skyMarket.reload();
+        builder.then(Commands.literal("reload")
+            .requires(ctx -> ctx.getSender().hasPermission("skymarket.commands.skymarket.reload"))
+            .executes(ctx -> {
+                skyMarket.reload();
 
-                                locale = localeLoader.getLocale();
+                Locale locale = localeLoader.getLocale();
 
-                                sender.sendMessage(FormatUtil.format(player, locale.prefix() + locale.configReload()));
-                                return true;
-                            } else {
-                                sender.sendMessage(FormatUtil.format(player, locale.prefix() + locale.noPermission()));
-                                return false;
-                            }
-                        } else {
-                            skyMarket.reload();
-                            skyMarket.getComponentLogger().info(FormatUtil.format(locale.configReload()));
-                            return true;
-                        }
-                    }
+                ctx.getSource().getSender().sendMessage(FormatUtil.format(locale.prefix() + locale.configReload()));
 
-                    case "refresh" -> {
-                        if(sender instanceof Player player) {
-                            if(player.hasPermission("skymarket.commands.skymarket.refresh")) {
-                                marketManager.refreshMarket();
+                return 1;
+            })
+        );
 
-                                return true;
-                            }
-                        }
-                    }
+        builder.then(Commands.literal("refresh")
+            .requires(ctx -> ctx.getSender().hasPermission("skymarket.commands.skymarket.refresh"))
+            .executes(ctx -> {
+                marketManager.refreshMarket();
 
-                    case "time" -> {
-                        if(sender instanceof Player player) {
-                            if(player.hasPermission("skymarket.commands.skymarket.time")) {
-                                SimpleDateFormat simpleDateFormat = marketManager.getSimpleDateFormat();
+                return 1;
+            })
+        );
 
-                                Date date = new Date(marketManager.getResetTime());
+        builder.then(Commands.literal("time")
+            .requires(ctx -> ctx.getSender().hasPermission("skymarket.commands.skymarket.time"))
+            .executes(ctx -> {
+                Locale locale = localeLoader.getLocale();
+                Time time = FormatUtil.millisToTime(marketManager.getResetTime() - System.currentTimeMillis());
 
-                                List<TagResolver.Single> placeholders = List.of(Placeholder.parsed("time", simpleDateFormat.format(date)));
+                StringBuilder stringBuilder = new StringBuilder();
 
-                                player.sendMessage(FormatUtil.format(locale.prefix() + locale.marketRefreshTime(), placeholders));
-
-                                return true;
-                            } else {
-                                sender.sendMessage(FormatUtil.format(player, locale.prefix() + locale.noPermission()));
-                                return false;
-                            }
-                        }
-                    }
-
-                    default -> {
-                        if (sender instanceof Player player) {
-                            player.sendMessage(FormatUtil.format(player, locale.prefix() + locale.unknownArgument(), new ArrayList<>()));
-                        } else {
-                            skyMarket.getComponentLogger().info(FormatUtil.format(locale.unknownArgument(), new ArrayList<>()));
-                        }
-
-                        return false;
+                if(time.years() > 0) {
+                    if(time.years() > 1) {
+                        stringBuilder.append(time.years()).append(" years ");
+                    } else {
+                        stringBuilder.append(time.years()).append(" year ");
                     }
                 }
-            }
 
-            default -> {
-                if(sender instanceof Player player) {
-                    player.sendMessage(FormatUtil.format(player,locale.prefix() + locale.unknownArgument()));
-                } else {
-                    skyMarket.getComponentLogger().info(FormatUtil.format(locale.unknownArgument()));
+                if(time.months() > 0) {
+                    if(time.months() > 1) {
+                        stringBuilder.append(time.months()).append(" months ");
+                    } else {
+                        stringBuilder.append(time.months()).append(" month ");
+                    }
                 }
-                return false;
-            }
-        }
 
-        return false;
-    }
+                if(time.weeks() > 0) {
+                    if(time.weeks() > 1) {
+                        stringBuilder.append(time.weeks()).append(" weeks ");
+                    } else {
+                        stringBuilder.append(time.weeks()).append(" week ");
+                    }
+                }
 
-    @Nullable
-    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if(args.length == 1) {
-            ArrayList<String> subCmds = new ArrayList<>();
-            if(sender instanceof Player) {
-                if(sender.hasPermission("skymarket.commands.skymarket.reload")) subCmds.add("reload");
-                if(sender.hasPermission("skymarket.commands.skymarket.time")) subCmds.add("time");
-            } else {
-                subCmds.add("reload");
-                subCmds.add("time");
-            }
+                if(time.days() > 0) {
+                    if(time.days() > 1) {
+                        stringBuilder.append(time.days()).append(" days ");
+                    } else {
+                        stringBuilder.append(time.days()).append(" day ");
+                    }
+                }
 
-            return subCmds;
-        }
+                if(time.hours() > 0) {
+                    if(time.hours() > 1) {
+                        stringBuilder.append(time.hours()).append(" hours ");
+                    } else {
+                        stringBuilder.append(time.hours()).append(" hour ");
+                    }
+                }
 
-        return Collections.emptyList();
+                if(time.minutes() > 0) {
+                    if(time.minutes() > 1) {
+                        stringBuilder.append(time.minutes()).append(" minutes ");
+                    } else {
+                        stringBuilder.append(time.minutes()).append(" minute ");
+                    }
+                }
+
+                if(time.seconds() > 0) {
+                    if(time.seconds() > 1) {
+                        stringBuilder.append(time.seconds()).append(" seconds ");
+                    } else {
+                        stringBuilder.append(time.seconds()).append(" second ");
+                    }
+                }
+
+                if(time.milliseconds() > 0) {
+                    if(time.milliseconds() > 1) {
+                        stringBuilder.append(time.milliseconds()).append(" milliseconds");
+                    } else {
+                        stringBuilder.append(time.milliseconds()).append(" millisecond");
+                    }
+                }
+
+                List<TagResolver.Single> placeholders = List.of(Placeholder.parsed("time", stringBuilder.toString()));
+
+                ctx.getSource().getSender().sendMessage(FormatUtil.format(locale.prefix() + locale.marketRefreshTime(), placeholders));
+
+                return 1;
+            })
+        );
+
+
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/github/lukesky19/skymarket/configuration/manager/LocaleLoader.java
+++ b/src/main/java/com/github/lukesky19/skymarket/configuration/manager/LocaleLoader.java
@@ -34,9 +34,8 @@ public class LocaleLoader {
     final SettingsLoader settingsLoader;
     private Locale locale;
     private final Locale defaultLocale = new Locale(
-            "1.1.1",
+            "1.2.0",
             "<gold><bold>SkyMarket</bold></gold><gray> ▪ </gray>",
-            "<red>You do not have permission for this command.</red>",
             "<aqua>Configuration files have been reloaded.</aqua>",
             "<red>You do not have enough items to sell.</red>",
             "<red>Insufficient funds.</red>",
@@ -45,10 +44,9 @@ public class LocaleLoader {
             "<red>This item is not able to be purchased.</red>",
             "<red>This item is not able to be sold.</red>",
             "<red>This command can only be ran in-game.</red>",
-            "<red>One or more of the arguments sent is not recognized.</red>",
             "<white>The black market has been refreshed.</white>",
             "<red>Unable to open the market due to a configuration issue.</red>",
-            "<white>The market will be refreshed at <yellow><time></yellow>.</white>");
+            "<white>The market will be refreshed in <yellow><time></yellow>.</white>");
 
     public LocaleLoader(SkyMarket skyMarket, SettingsLoader settingsLoader) {
         this.skyMarket = skyMarket;
@@ -109,16 +107,15 @@ public class LocaleLoader {
 
     private void migrateLocale() {
         switch(locale.configVersion()) {
-            case "1.1.1" -> {
+            case "1.2.0" -> {
                 // Current version, do nothing.
             }
 
             case "1.1.0" -> {
-                // Version 1.1.0 -> 1.1.1
+                // Version 1.1.0 -> 1.2.0
                 Locale newLocale = new Locale(
-                        "1.1.1",
+                        "1.2.0",
                         locale.prefix().trim(),
-                        locale.noPermission(),
                         locale.configReload(),
                         locale.notEnoughItems(),
                         locale.insufficientFunds(),
@@ -127,10 +124,9 @@ public class LocaleLoader {
                         locale.unbuyable(),
                         locale.unsellable(),
                         locale.inGameOnly(),
-                        locale.unknownArgument(),
                         locale.marketRefreshed(),
                         locale.marketOpenError(),
-                        locale.marketRefreshTime());
+                        "<white>The market will be refreshed in <yellow><time></yellow>.</white>");
 
                 locale = newLocale;
 
@@ -138,11 +134,10 @@ public class LocaleLoader {
             }
 
             case null -> {
-                // Version 1.0.0 -> 1.1.1
+                // Version 1.0.0 -> 1.2.0
                 Locale newLocale = new Locale(
-                        "1.1.1",
+                        "1.2.0",
                         locale.prefix().trim(),
-                        locale.noPermission(),
                         locale.configReload(),
                         locale.notEnoughItems(),
                         locale.insufficientFunds(),
@@ -151,10 +146,9 @@ public class LocaleLoader {
                         locale.unbuyable(),
                         locale.unsellable(),
                         locale.inGameOnly(),
-                        locale.unknownArgument(),
                         "<white>The market has been refreshed.</white>",
                         "<red>Unable to open the market due to a configuration issue.</red>",
-                        "<white>The market will be refreshed at <yellow><time></yellow>.</white>");
+                        "<white>The market will be refreshed in <yellow><time></yellow>.</white>");
 
                 locale = newLocale;
 

--- a/src/main/java/com/github/lukesky19/skymarket/configuration/manager/LocaleLoader.java
+++ b/src/main/java/com/github/lukesky19/skymarket/configuration/manager/LocaleLoader.java
@@ -34,7 +34,7 @@ public class LocaleLoader {
     final SettingsLoader settingsLoader;
     private Locale locale;
     private final Locale defaultLocale = new Locale(
-            "1.1.0",
+            "1.1.1",
             "<gold><bold>SkyMarket</bold></gold><gray> ▪ </gray>",
             "<red>You do not have permission for this command.</red>",
             "<aqua>Configuration files have been reloaded.</aqua>",
@@ -109,15 +109,39 @@ public class LocaleLoader {
 
     private void migrateLocale() {
         switch(locale.configVersion()) {
-            case "1.1.0" -> {
+            case "1.1.1" -> {
                 // Current version, do nothing.
             }
 
-            case null -> {
-                // Version 1.0.0 -> 1.1.0
+            case "1.1.0" -> {
+                // Version 1.1.0 -> 1.1.1
                 Locale newLocale = new Locale(
-                        "1.1.0",
-                        locale.prefix(),
+                        "1.1.1",
+                        locale.prefix().trim(),
+                        locale.noPermission(),
+                        locale.configReload(),
+                        locale.notEnoughItems(),
+                        locale.insufficientFunds(),
+                        locale.buySuccess(),
+                        locale.sellSuccess(),
+                        locale.unbuyable(),
+                        locale.unsellable(),
+                        locale.inGameOnly(),
+                        locale.unknownArgument(),
+                        locale.marketRefreshed(),
+                        locale.marketOpenError(),
+                        locale.marketRefreshTime());
+
+                locale = newLocale;
+
+                saveLocale(newLocale);
+            }
+
+            case null -> {
+                // Version 1.0.0 -> 1.1.1
+                Locale newLocale = new Locale(
+                        "1.1.1",
+                        locale.prefix().trim(),
                         locale.noPermission(),
                         locale.configReload(),
                         locale.notEnoughItems(),

--- a/src/main/java/com/github/lukesky19/skymarket/configuration/record/Locale.java
+++ b/src/main/java/com/github/lukesky19/skymarket/configuration/record/Locale.java
@@ -23,7 +23,6 @@ import com.github.lukesky19.skylib.libs.configurate.objectmapping.ConfigSerializ
 public record Locale(
         String configVersion,
         String prefix,
-        String noPermission,
         String configReload,
         String notEnoughItems,
         String insufficientFunds,
@@ -32,7 +31,6 @@ public record Locale(
         String unbuyable,
         String unsellable,
         String inGameOnly,
-        String unknownArgument,
         String marketRefreshed,
         String marketOpenError,
         String marketRefreshTime) {

--- a/src/main/java/com/github/lukesky19/skymarket/manager/MarketManager.java
+++ b/src/main/java/com/github/lukesky19/skymarket/manager/MarketManager.java
@@ -12,11 +12,8 @@ import com.github.lukesky19.skymarket.gui.MarketGUI;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckForNull;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
 
 public class MarketManager {
     private final SkyMarket skyMarket;
@@ -28,7 +25,6 @@ public class MarketManager {
     private BukkitTask task;
 
     private long resetTime;
-    private final SimpleDateFormat simpleDateFormat;
 
     public MarketManager(SkyMarket skyMarket, SettingsLoader settingsLoader, LocaleLoader localeLoader, ItemsLoader itemsLoader, MarketLoader marketLoader) {
         this.skyMarket = skyMarket;
@@ -36,19 +32,11 @@ public class MarketManager {
         this.localeLoader = localeLoader;
         this.itemsLoader = itemsLoader;
         this.marketLoader = marketLoader;
-
-        simpleDateFormat = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss z");
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("America/New_York"));
     }
 
     @CheckForNull
     public MarketGUI getMarketGUI() {
         return marketGUI;
-    }
-
-    @NotNull
-    public SimpleDateFormat getSimpleDateFormat() {
-        return simpleDateFormat;
     }
 
     public long getResetTime() {

--- a/src/main/resources/locale/en_US.yml
+++ b/src/main/resources/locale/en_US.yml
@@ -1,7 +1,6 @@
-config-version: 1.1.0
+config-version: 1.2.0
 # Prefix is placed in-front of all other messages automatically.
 prefix: "<gold><bold>SkyMarket</bold></gold><gray> ▪ </gray>"
-no-permission: "<red>You do not have permission for this command.</red>"
 config-reload: "<aqua>Configuration files have been reloaded.</aqua>"
 not-enough-items: "<red>You do not have enough items to sell.</red>"
 insufficient-funds: "<red>Insufficient funds.</red>"
@@ -12,7 +11,6 @@ sell-success: "<white>Sold <yellow><amount> <item></yellow> for <yellow><price><
 unbuyable: "<red>This item is not able to be purchased.</red>"
 unsellable: "<red>This item is not able to be sold.</red>"
 in-game-only: "<red>This command can only be ran in-game.</red>"
-unknown-argument: "<red>One or more of the arguments sent is not recognized.</red>"
 market-refreshed: "<white>The market has been refreshed.</white>"
 market-open-error: "<red>Unable to open the market due to a configuration issue.</red>"
-market-refresh-time: "<white>The market will be refreshed at <yellow><time></yellow>.</white>"
+market-refresh-time: "<white>The market will be refreshed in <yellow><time></yellow>.</white>"

--- a/src/main/resources/locale/en_US.yml
+++ b/src/main/resources/locale/en_US.yml
@@ -1,6 +1,6 @@
 config-version: 1.1.0
 # Prefix is placed in-front of all other messages automatically.
-prefix: "<gold><bold>SkyMarket</bold></gold><gray> ▪ </gray> "
+prefix: "<gold><bold>SkyMarket</bold></gold><gray> ▪ </gray>"
 no-permission: "<red>You do not have permission for this command.</red>"
 config-reload: "<aqua>Configuration files have been reloaded.</aqua>"
 not-enough-items: "<red>You do not have enough items to sell.</red>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,15 +7,6 @@ author: lukeskywlker19
 description: A rotating shop plugin
 depend: [SkyLib, Vault]
 
-commands:
-  skymarket:
-    description: The base command.
-    aliases:
-      - sm
-      - skm
-      - market
-      - blackmarket
-      - bm
 permissions:
   skymarket.commands.skymarket:
     description: Permission to access the shop.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,3 +23,6 @@ permissions:
   skymarket.commands.skymarket.reload:
     description: Permission to reload the plugin.
     default: op
+  skymarket.commands.skymarket.time:
+    description: Permission to view when the market will refresh.
+    default: op


### PR DESCRIPTION
* Bump version
* Add "skymarket.commands.skymarket.time" to plugin.yml's permissions.
* Add missing no permission message for /skymarket time.
* Fix wrong permissions in SkyMarketCommand#onTabComplete and missing tab completion for /skymarket time.
* Remove extra space for the prefix message in en_US.yml.
* Bump version
* Move to the Brigadier API
* Change how the time until the market refresh is displayed.
* Removed refreshing the market on reload.
* Remove commands section from plugin.yml as it's not needed anymore.
* Update Paper and Vault dependencies.
* Update README.md
* Remove repository for PlaceholderAPI from build.gradle.kts